### PR TITLE
Native Implementation Overrides

### DIFF
--- a/ExposureNotification.App/ExposureNotification.App/App.xaml.cs
+++ b/ExposureNotification.App/ExposureNotification.App/App.xaml.cs
@@ -13,8 +13,8 @@ namespace ExposureNotification.App
 #if DEBUG
 			// For debug mode, set the mock api provider to interact
 			// with some fake data
-			Xamarin.ExposureNotifications.ExposureNotification.MockApi =
-				new Services.MockApi();
+			Xamarin.ExposureNotifications.ExposureNotification.OverrideNativeImplementation(
+				new Services.TestNativeImplementation());
 #endif
 
 			MainPage = new AppShell();

--- a/ExposureNotification.App/ExposureNotification.App/App.xaml.cs
+++ b/ExposureNotification.App/ExposureNotification.App/App.xaml.cs
@@ -10,6 +10,13 @@ namespace ExposureNotification.App
 		{
 			InitializeComponent();
 
+#if DEBUG
+			// For debug mode, set the mock api provider to interact
+			// with some fake data
+			Xamarin.ExposureNotifications.ExposureNotification.MockApi =
+				new Services.MockApi();
+#endif
+
 			MainPage = new AppShell();
 		}
 

--- a/ExposureNotification.App/ExposureNotification.App/Services/MockApi.cs
+++ b/ExposureNotification.App/ExposureNotification.App/Services/MockApi.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.ExposureNotifications;
+using System.Threading.Tasks;
+using Xamarin.Essentials;
+
+namespace ExposureNotification.App.Services
+{
+	public class MockApi : IMockExposureNotificationApi
+	{
+		static readonly Random random = new Random();
+
+		Task WaitRandom()
+			=> Task.Delay(random.Next(100, 2500));
+
+		public async Task StartAsync()
+		{
+			await WaitRandom();
+			Preferences.Set("fake_enabled", true);
+		}
+
+		public async Task StopAsync()
+		{
+			await WaitRandom();
+			Preferences.Set("fake_enabled", false);
+		}
+
+		public async Task<bool> IsEnabledAsync()
+		{
+			await WaitRandom();
+			return Preferences.Get("fake_enabled", false);
+		}
+
+		public async Task<IEnumerable<TemporaryExposureKey>> GetSelfTemporaryExposureKeysAsync()
+		{
+			var keys = new List<TemporaryExposureKey>();
+
+			for (var i = 1; i < 14; i++)
+				keys.Add(GenerateRandomKey(i));
+
+			await WaitRandom();
+
+			return keys;
+		}
+
+		public Task<(ExposureDetectionSummary summary, IEnumerable<ExposureInfo> info)> DetectExposuresAsync(TemporaryExposureKeyBatches batches)
+		{
+			var summary = new ExposureDetectionSummary(10, 2, 5);
+
+			var info = new List<ExposureInfo>
+			{
+				new ExposureInfo (DateTime.UtcNow.AddDays(-10), TimeSpan.FromMinutes(15), 65, 5, RiskLevel.Medium),
+				new ExposureInfo (DateTime.UtcNow.AddDays(-11), TimeSpan.FromMinutes(5), 40, 3, RiskLevel.Low),
+			};
+
+			return Task.FromResult((summary, (IEnumerable<ExposureInfo>)info));
+		}
+
+		static TemporaryExposureKey GenerateRandomKey(int daysAgo)
+		{
+			var buffer = new byte[16];
+			random.NextBytes(buffer);
+
+			return new TemporaryExposureKey(
+				buffer,
+				DateTimeOffset.UtcNow.AddDays(-1 * daysAgo),
+				TimeSpan.FromMinutes(random.Next(5, 120)),
+				(RiskLevel)random.Next(1, 8));
+		}
+	}
+}

--- a/ExposureNotification.App/ExposureNotification.App/Services/TestNativeImplementation.cs
+++ b/ExposureNotification.App/ExposureNotification.App/Services/TestNativeImplementation.cs
@@ -7,7 +7,7 @@ using Xamarin.Essentials;
 
 namespace ExposureNotification.App.Services
 {
-	public class MockApi : IMockExposureNotificationApi
+	public class TestNativeImplementation : INativeImplementation
 	{
 		static readonly Random random = new Random();
 

--- a/ExposureNotification.App/ExposureNotification.App/ViewModels/InfoViewModel.cs
+++ b/ExposureNotification.App/ExposureNotification.App/ViewModels/InfoViewModel.cs
@@ -12,23 +12,23 @@ namespace ExposureNotification.App.ViewModels
 	{
 		public InfoViewModel()
 		{
-			//Xamarin.ExposureNotifications.ExposureNotification.IsEnabledAsync()
-			//	.ContinueWith(t =>
-			//	{
-			//		IsEnabled = t.Result;
-			//	});
+			Xamarin.ExposureNotifications.ExposureNotification.IsEnabledAsync()
+				.ContinueWith(t =>
+				{
+					IsEnabled = t.Result;
+				});
 		}
 
 		public bool IsEnabled
-        {
+		{
 			get => LocalStateManager.Instance.LastIsEnabled;
 			set
-            {
+			{
 				LocalStateManager.Instance.LastIsEnabled = value;
 				LocalStateManager.Save();
 				NotifyPropertyChanged(nameof(IsEnabled));
-            }
-        }
+			}
+		}
 
 		public bool IsWelcomed
 		{
@@ -50,6 +50,8 @@ namespace ExposureNotification.App.ViewModels
 					await Xamarin.ExposureNotifications.ExposureNotification.StopAsync();
 				else
 					await Xamarin.ExposureNotifications.ExposureNotification.StartAsync();
+
+				IsEnabled = enabled;
 			});
 
 		public ICommand GetStartedCommand

--- a/Xamarin.ExposureNotification/ExposureNotification.shared.cs
+++ b/Xamarin.ExposureNotification/ExposureNotification.shared.cs
@@ -79,12 +79,12 @@ namespace Xamarin.ExposureNotifications
 
 			if (MockApi != null)
 			{
-				var (summary, info) = await MockApi.DetectExposuresAsync(batches);
+				var r = await MockApi.DetectExposuresAsync(batches);
 
-				var hasMatches = (summary?.MatchedKeyCount ?? 0) > 0;
+				var hasMatches = (r.summary?.MatchedKeyCount ?? 0) > 0;
 
 				if (hasMatches)
-					await Handler.ExposureDetectedAsync(summary, info);
+					await Handler.ExposureDetectedAsync(r.summary, r.info);
 
 				return true;
 			}

--- a/Xamarin.ExposureNotification/ExposureNotification.shared.cs
+++ b/Xamarin.ExposureNotification/ExposureNotification.shared.cs
@@ -10,7 +10,10 @@ namespace Xamarin.ExposureNotifications
 {
 	public static partial class ExposureNotification
 	{
-		public static IMockExposureNotificationApi MockApi { get; set; }
+		static INativeImplementation nativeImplementation;
+
+		public static void OverrideNativeImplementation(INativeImplementation nativeImplementation)
+			=> ExposureNotification.nativeImplementation = nativeImplementation;
 
 		static IExposureNotificationHandler handler;
 

--- a/Xamarin.ExposureNotification/ExposureNotification.shared.cs
+++ b/Xamarin.ExposureNotification/ExposureNotification.shared.cs
@@ -54,13 +54,13 @@ namespace Xamarin.ExposureNotifications
 		}
 
 		public static Task StartAsync()
-			=> MockApi != null ? MockApi.StartAsync() : PlatformStart();
+			=> nativeImplementation != null ? nativeImplementation.StartAsync() : PlatformStart();
 
 		public static Task StopAsync()
-			=> MockApi != null ? MockApi.StopAsync() : PlatformStop();
+			=> nativeImplementation != null ? nativeImplementation.StopAsync() : PlatformStop();
 
 		public static Task<bool> IsEnabledAsync()
-			=> MockApi != null ? MockApi.IsEnabledAsync() : PlatformIsEnabled();
+			=> nativeImplementation != null ? nativeImplementation.IsEnabledAsync() : PlatformIsEnabled();
 
 		// Call this when the user has confirmed diagnosis
 		public static async Task SubmitSelfDiagnosisAsync()
@@ -80,9 +80,9 @@ namespace Xamarin.ExposureNotifications
 			if (!batches.Files.Any())
 				return false;
 
-			if (MockApi != null)
+			if (nativeImplementation != null)
 			{
-				var r = await MockApi.DetectExposuresAsync(batches);
+				var r = await nativeImplementation.DetectExposuresAsync(batches);
 
 				var hasMatches = (r.summary?.MatchedKeyCount ?? 0) > 0;
 
@@ -108,7 +108,7 @@ namespace Xamarin.ExposureNotifications
 		}
 
 		internal static Task<IEnumerable<TemporaryExposureKey>> GetSelfTemporaryExposureKeysAsync()
-			=> MockApi != null ? MockApi.GetSelfTemporaryExposureKeysAsync() : PlatformGetTemporaryExposureKeys();
+			=> nativeImplementation != null ? nativeImplementation.GetSelfTemporaryExposureKeysAsync() : PlatformGetTemporaryExposureKeys();
 	}
 
 	public class Configuration

--- a/Xamarin.ExposureNotification/IExposureNotificationHandler.shared.cs
+++ b/Xamarin.ExposureNotification/IExposureNotificationHandler.shared.cs
@@ -25,7 +25,7 @@ namespace Xamarin.ExposureNotifications
 		Task AddBatchAsync(Proto.File file);
 	}
 
-	public interface IMockExposureNotificationApi
+	public interface INativeImplementation
 	{
 		Task StartAsync();
 		Task StopAsync();

--- a/Xamarin.ExposureNotification/IExposureNotificationHandler.shared.cs
+++ b/Xamarin.ExposureNotification/IExposureNotificationHandler.shared.cs
@@ -24,4 +24,13 @@ namespace Xamarin.ExposureNotifications
 
 		Task AddBatchAsync(Proto.File file);
 	}
+
+	public interface IMockExposureNotificationApi
+	{
+		Task StartAsync();
+		Task StopAsync();
+		Task<bool> IsEnabledAsync();
+		Task<(ExposureDetectionSummary summary, IEnumerable<ExposureInfo> info)> DetectExposuresAsync(TemporaryExposureKeyBatches batches);
+		Task<IEnumerable<TemporaryExposureKey>> GetSelfTemporaryExposureKeysAsync();
+	}
 }


### PR DESCRIPTION
In the spirit of Essentials, the cross platform API is basically a static thing, and there's no interface.  Rather than break everyone completely again, I have added a simple interface that you can set an instance of on the static API.  If that instance is set, your mock is used.

This also adds to the sample a mock implementation.  Next we'll deploy the azure function with some sample data in the database (perhaps with another timed function to add some mocked data into the database and actually see the timer create batch files and allow the client to start actually pulling them down).