### PR TITLE
Remove date from diagnosis submission

### DIFF
--- a/ExposureNotification.App/ExposureNotification.App/ViewModels/SharePositiveDiagnosisViewModel.cs
+++ b/ExposureNotification.App/ExposureNotification.App/ViewModels/SharePositiveDiagnosisViewModel.cs
@@ -15,8 +15,6 @@ namespace ExposureNotification.App.ViewModels
 		}
 		public string DiagnosisUid { get; set; }
 
-		public DateTime? DiagnosisTimestamp { get; set; } = DateTime.Now;
-
 		public AsyncCommand CancelCommand
 			=> new AsyncCommand(() => GoToAsync(".."));
 
@@ -27,11 +25,6 @@ namespace ExposureNotification.App.ViewModels
 				if (string.IsNullOrEmpty(DiagnosisUid))
 				{
 					await UserDialogs.Instance.AlertAsync("Please provide a valid Diagnosis ID", "Invalid Diagnosis ID", "OK");
-					return;
-				}
-				if (!DiagnosisTimestamp.HasValue || DiagnosisTimestamp.Value > DateTime.Now)
-				{
-					await UserDialogs.Instance.AlertAsync("Please provide a valid Test Date", "Invalid Test Date", "OK");
 					return;
 				}
 
@@ -51,7 +44,7 @@ namespace ExposureNotification.App.ViewModels
 					}
 
 					// Set the submitted UID
-					LocalStateManager.Instance.AddDiagnosis(DiagnosisUid, new DateTimeOffset(DiagnosisTimestamp.Value));
+					LocalStateManager.Instance.AddDiagnosis(DiagnosisUid, DateTimeOffset.UtcNow);
 					LocalStateManager.Save();
 
 					// Submit our diagnosis

--- a/ExposureNotification.App/ExposureNotification.App/Views/SharePositiveDiagnosisPage.xaml
+++ b/ExposureNotification.App/ExposureNotification.App/Views/SharePositiveDiagnosisPage.xaml
@@ -59,24 +59,12 @@
                             BackgroundColor="{DynamicResource BackgroundColor}"
                             Text="{Binding DiagnosisUid, Mode=TwoWay}" />
 
-                        <Label
+						<Label
                             Margin="0,12,0,0"
                             Style="{DynamicResource SmallLabelStyle}"
                             Text="The unique test identifier that came with your COVID-19 test must be used to verify your positive test result." />
 
-                        <DatePicker
-                            Margin="0,20,0,0"
-                            Date="{Binding DiagnosisTimestamp}"
-                            Style="{DynamicResource DatePickerStyle}"
-                            BackgroundColor="{DynamicResource BackgroundColor}"/>
-
-                        <Label
-                            Margin="0,12,0,0"
-                            Style="{DynamicResource SmallLabelStyle}"
-                            Text="The test date helps the app know when you may have been contagious and notify the right people of potential exposure." />
-
-
-                        <Button
+						<Button
                             Command="{Binding SubmitDiagnosisCommand}"
                             HorizontalOptions="End"
                             IsEnabled="{Binding IsEnabled}"


### PR DESCRIPTION
The samples from Apple/Google no longer seem to use this field, and they aren't submitted to the server now anyway, so they should be removed.