### PR TITLE
Add Exported=True to broadcast receiver declaration

### DIFF
--- a/Xamarin.ExposureNotification/CallbackService.android.cs
+++ b/Xamarin.ExposureNotification/CallbackService.android.cs
@@ -6,7 +6,9 @@ using AndroidX.Core.App;
 
 namespace Xamarin.ExposureNotifications
 {
-	[BroadcastReceiver(Permission = "com.google.android.gms.nearby.exposurenotification.EXPOSURE_CALLBACK")]
+	[BroadcastReceiver(
+		Permission = "com.google.android.gms.nearby.exposurenotification.EXPOSURE_CALLBACK",
+		Exported = true)]
 	[IntentFilter(new[] { ExposureNotificationClient.ActionExposureStateUpdated })]
 	[Preserve]
 	class ExposureNotificationCallbackBroadcastReceiver : BroadcastReceiver

--- a/Xamarin.ExposureNotification/ExposureNotification.android.cs
+++ b/Xamarin.ExposureNotification/ExposureNotification.android.cs
@@ -15,6 +15,8 @@ using Java.Nio.FileNio;
 using AndroidRiskLevel = Android.Gms.Nearby.ExposureNotification.RiskLevel;
 using Nearby = Android.Gms.Nearby.NearbyClass;
 
+[assembly: UsesFeature("android.hardware.bluetooth_le", Required=true)]
+[assembly: UsesFeature("android.hardware.bluetooth")]
 [assembly: UsesPermission(Android.Manifest.Permission.Bluetooth)]
 [assembly: UsesPermission(Android.Manifest.Permission.AccessNetworkState)]
 

--- a/Xamarin.ExposureNotification/ExposureNotification.android.cs
+++ b/Xamarin.ExposureNotification/ExposureNotification.android.cs
@@ -18,7 +18,7 @@ using Nearby = Android.Gms.Nearby.NearbyClass;
 [assembly: UsesFeature("android.hardware.bluetooth_le", Required=true)]
 [assembly: UsesFeature("android.hardware.bluetooth")]
 [assembly: UsesPermission(Android.Manifest.Permission.Bluetooth)]
-[assembly: UsesPermission(Android.Manifest.Permission.AccessNetworkState)]
+
 
 namespace Xamarin.ExposureNotifications
 {


### PR DESCRIPTION
This should fix #55 and should also make #63 unnecessary.

Looking at the difference between Google's sample and ours, we did not add `exported=true` to our manifest.  Updating this attribute I've confirmed does cause the correct broadcast receiver declaration to end up in the androidmanifest.xml file (`obj/Debug/100/android/AndroidManifest.xml`)