### PR TITLE
Use a delegate to fetch additional info

### DIFF
--- a/ExposureNotification.App/ExposureNotification.App/Services/ExposureNotificationHandler.cs
+++ b/ExposureNotification.App/ExposureNotification.App/Services/ExposureNotificationHandler.cs
@@ -29,9 +29,11 @@ namespace ExposureNotification.App
 			=> Task.FromResult(new Configuration());
 
 		// this will be called when a potential exposure has been detected
-		public async Task ExposureDetectedAsync(ExposureDetectionSummary summary, IEnumerable<ExposureInfo> exposureInfo)
+		public async Task ExposureDetectedAsync(ExposureDetectionSummary summary, Func<Task<IEnumerable<ExposureInfo>>> getExposureInfo)
 		{
 			LocalStateManager.Instance.ExposureSummary = summary;
+
+			var exposureInfo = await getExposureInfo();
 
 			// Add these on main thread in case the UI is visible so it can update
 			await Device.InvokeOnMainThreadAsync(() =>
@@ -42,8 +44,8 @@ namespace ExposureNotification.App
 
 			LocalStateManager.Save();
 			// If Enabled Local Notifications
-            if (LocalStateManager.Instance.EnableNotifications)
-            {
+			if (LocalStateManager.Instance.EnableNotifications)
+			{
 				var notification = new NotificationRequest
 				{
 					NotificationId = 100,

--- a/ExposureNotification.App/ExposureNotification.App/Services/TestNativeImplementation.cs
+++ b/ExposureNotification.App/ExposureNotification.App/Services/TestNativeImplementation.cs
@@ -47,17 +47,21 @@ namespace ExposureNotification.App.Services
 		public Task<Status> GetStatusAsync()
 			=> Task.FromResult(Preferences.Get("fake_enabled", false) ? Status.Active : Status.Disabled);
 
-		public Task<(ExposureDetectionSummary summary, IEnumerable<ExposureInfo> info)> DetectExposuresAsync(IEnumerable<string> files)
+		public Task<(ExposureDetectionSummary summary, Func<Task<IEnumerable<ExposureInfo>>> getInfo)> DetectExposuresAsync(IEnumerable<string> files)
 		{
 			var summary = new ExposureDetectionSummary(10, 2, 5);
 
-			var info = new List<ExposureInfo>
+			Task<IEnumerable<ExposureInfo>> GetInfo()
 			{
-				new ExposureInfo (DateTime.UtcNow.AddDays(-10), TimeSpan.FromMinutes(15), 65, 5, RiskLevel.Medium),
-				new ExposureInfo (DateTime.UtcNow.AddDays(-11), TimeSpan.FromMinutes(5), 40, 3, RiskLevel.Low),
-			};
+				var info = new List<ExposureInfo>
+				{
+					new ExposureInfo (DateTime.UtcNow.AddDays(-10), TimeSpan.FromMinutes(15), 65, 5, RiskLevel.Medium),
+					new ExposureInfo (DateTime.UtcNow.AddDays(-11), TimeSpan.FromMinutes(5), 40, 3, RiskLevel.Low),
+				};
+				return Task.FromResult<IEnumerable<ExposureInfo>>(info);
+			}
 
-			return Task.FromResult((summary, (IEnumerable<ExposureInfo>)info));
+			return Task.FromResult<(ExposureDetectionSummary, Func<Task<IEnumerable<ExposureInfo>>>)>((summary, GetInfo));
 		}
 
 		static TemporaryExposureKey GenerateRandomKey(int daysAgo)

--- a/Xamarin.ExposureNotification/CallbackService.android.cs
+++ b/Xamarin.ExposureNotification/CallbackService.android.cs
@@ -1,4 +1,6 @@
-﻿using Android.App;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Android.App;
 using Android.Content;
 using Android.Gms.Nearby.ExposureNotification;
 using Android.Runtime;
@@ -32,12 +34,15 @@ namespace Xamarin.ExposureNotifications
 
 			var summary = await ExposureNotification.PlatformGetExposureSummaryAsync(token);
 
+			Task<IEnumerable<ExposureInfo>> GetInfo()
+			{
+				return ExposureNotification.PlatformGetExposureInformationAsync(token);
+			}
+
 			// Invoke the custom implementation handler code with the summary info
 			if (summary?.MatchedKeyCount > 0)
 			{
-				var info = await ExposureNotification.PlatformGetExposureInformationAsync(token);
-
-				await ExposureNotification.Handler.ExposureDetectedAsync(summary, info);
+				await ExposureNotification.Handler.ExposureDetectedAsync(summary, GetInfo);
 			}
 		}
 	}

--- a/Xamarin.ExposureNotification/ExposureNotification.shared.cs
+++ b/Xamarin.ExposureNotification/ExposureNotification.shared.cs
@@ -99,7 +99,7 @@ namespace Xamarin.ExposureNotifications
 					var hasMatches = (r.summary?.MatchedKeyCount ?? 0) > 0;
 
 					if (hasMatches)
-						await Handler.ExposureDetectedAsync(r.summary, r.info);
+						await Handler.ExposureDetectedAsync(r.summary, r.getInfo);
 				}
 				else
 				{

--- a/Xamarin.ExposureNotification/IExposureNotificationHandler.shared.cs
+++ b/Xamarin.ExposureNotification/IExposureNotificationHandler.shared.cs
@@ -15,7 +15,7 @@ namespace Xamarin.ExposureNotifications
 		Task FetchExposureKeyBatchFilesFromServerAsync(Func<IEnumerable<string>, Task> submitBatches, CancellationToken cancellationToken);
 
 		// Might be exposed, check and alert user if necessary
-		Task ExposureDetectedAsync(ExposureDetectionSummary summary, IEnumerable<ExposureInfo> ExposureInfo);
+		Task ExposureDetectedAsync(ExposureDetectionSummary summary, Func<Task<IEnumerable<ExposureInfo>>> getExposureInfo);
 
 		Task UploadSelfExposureKeysToServerAsync(IEnumerable<TemporaryExposureKey> temporaryExposureKeys);
 	}
@@ -28,7 +28,7 @@ namespace Xamarin.ExposureNotifications
 
 		Task<bool> IsEnabledAsync();
 
-		Task<(ExposureDetectionSummary summary, IEnumerable<ExposureInfo> info)> DetectExposuresAsync(IEnumerable<string> files);
+		Task<(ExposureDetectionSummary summary, Func<Task<IEnumerable<ExposureInfo>>> getInfo)> DetectExposuresAsync(IEnumerable<string> files);
 
 		Task<IEnumerable<TemporaryExposureKey>> GetSelfTemporaryExposureKeysAsync();
 


### PR DESCRIPTION
This resolves #66.

We can't use an option, because this is not an immediate result, and Android uses a delayed callback. So instead, at the time of reading, make the decision of whether you want the info or not.

*Mobile app changes*

Switch the parameter type:
```diff
-public async Task ExposureDetectedAsync(ExposureDetectionSummary summary, IEnumerable<ExposureInfo> exposureInfo)
+public async Task ExposureDetectedAsync(ExposureDetectionSummary summary, Func<Task<IEnumerable<ExposureInfo>>> getExposureInfo)
```

Add this line when you want the info:
```csharp
var exposureInfo = await getExposureInfo();
```