### PR TITLE
Allow setting max files per batch and default to 1

### DIFF
--- a/ExposureNotification.Backend.Functions/Database/ExposureNotificationStorage.cs
+++ b/ExposureNotification.Backend.Functions/Database/ExposureNotificationStorage.cs
@@ -27,7 +27,8 @@ namespace ExposureNotification.Backend.Database
 			this.context = context;
 			this.settings = settings.Value;
 
-			this.context.Database.SetCommandTimeout(900);
+			if (!context.Database.IsInMemory() && this.settings.DbCommandTimeout > 0)
+				this.context.Database.SetCommandTimeout(this.settings.DbCommandTimeout);
 		}
 
 		public ValueTask DisposeAsync() =>

--- a/ExposureNotification.Backend.Functions/Database/ExposureNotificationStorage.cs
+++ b/ExposureNotification.Backend.Functions/Database/ExposureNotificationStorage.cs
@@ -132,6 +132,8 @@ namespace ExposureNotification.Backend.Database
 			var nowEpochSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 			var twoHoursAgoEpochSeconds = nowEpochSeconds - 7200; // 2 hours ago
 
+			var maxKeysInBatch = maxFilesPerBatch * TemporaryExposureKeyExport.MaxKeysPerFile;
+
 			var keys = context.TemporaryExposureKeys
 				.Where(k => k.Region == region
 							&& !k.Processed
@@ -140,7 +142,7 @@ namespace ExposureNotification.Backend.Database
 							// Do not distribute temporary exposure key data until at least 2 hours after the end of the keyʼs expiration window
 							&& (k.RollingStartSecondsSinceEpoch + (k.RollingDuration * 10 * 60)) < twoHoursAgoEpochSeconds)
 				.OrderBy(k => k.Id) // Randomize the order in the export file
-				.Take(maxFilesPerBatch * TemporaryExposureKeyExport.MaxKeysPerFile);
+				.Take(maxKeysInBatch);
 
 			// How many keys do we need to put in batchfiles
 			var totalCount = await keys.CountAsync();

--- a/ExposureNotification.Backend.Functions/Settings.cs
+++ b/ExposureNotification.Backend.Functions/Settings.cs
@@ -5,6 +5,7 @@ namespace ExposureNotification.Backend.Functions
 	public class Settings
 	{
 		public string DbConnectionString { get; set; }
+		public int DbCommandTimeout { get; set; } = -1;
 
 		public string BlobStorageConnectionString { get; set; }
 

--- a/ExposureNotification.Backend.Functions/Settings.cs
+++ b/ExposureNotification.Backend.Functions/Settings.cs
@@ -27,6 +27,8 @@ namespace ExposureNotification.Backend.Functions
 		public string iOSDeviceCheckTeamId { get; set; }
 		public string iOSDeviceCheckPrivateKey { get; set; }
 
+		public int MaxFilesPerBatch { get; set; } = 1;		
+
 
 		public override string ToString()
 		{

--- a/ExposureNotification.Backend.Functions/Startup.cs
+++ b/ExposureNotification.Backend.Functions/Startup.cs
@@ -62,6 +62,7 @@ namespace ExposureNotification.Backend.Functions
 				settings.iOSDeviceCheckKeyId = config["EN-iOS-DeviceCheck-KeyId"];
 				settings.iOSDeviceCheckPrivateKey = config["EN-iOS-DeviceCheck-PrivateKey"];
 				
+				settings.DbCommandTimeout = config.GetValue<int>("EN-DbCommandTimeout", -1);
 				logger.LogInformation($"Configuration Values:\r\n{settings}");
 			});
 

--- a/ExposureNotification.Backend.Functions/Startup.cs
+++ b/ExposureNotification.Backend.Functions/Startup.cs
@@ -61,8 +61,11 @@ namespace ExposureNotification.Backend.Functions
 				settings.iOSDeviceCheckTeamId = config["EN-iOS-DeviceCheck-TeamId"];
 				settings.iOSDeviceCheckKeyId = config["EN-iOS-DeviceCheck-KeyId"];
 				settings.iOSDeviceCheckPrivateKey = config["EN-iOS-DeviceCheck-PrivateKey"];
-				
+
+				// Currently apple only supports 1 file per batch
+				settings.MaxFilesPerBatch = config.GetValue<int>("EN-MaxFilesPerBatch", 1);
 				settings.DbCommandTimeout = config.GetValue<int>("EN-DbCommandTimeout", -1);
+
 				logger.LogInformation($"Configuration Values:\r\n{settings}");
 			});
 


### PR DESCRIPTION
Apple seems to support only 1 file per batch currently, so moving the max files per batch to an app setting in the function and defaulting it to 1.