### PR TITLE
Use the correct data type for the MaximumRiskScore property

### DIFF
--- a/Xamarin.ExposureNotification/ExposureInfo.shared.cs
+++ b/Xamarin.ExposureNotification/ExposureInfo.shared.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace Xamarin.ExposureNotifications
 {
@@ -32,16 +33,28 @@ namespace Xamarin.ExposureNotifications
 
 	public class ExposureDetectionSummary
 	{
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public ExposureDetectionSummary(int daysSinceLastExposure, ulong matchedKeyCount, byte maximumRiskScore)
-			: this(daysSinceLastExposure, matchedKeyCount, maximumRiskScore, null, 0)
+			: this(daysSinceLastExposure, matchedKeyCount, (int)maximumRiskScore, null, 0)
 		{
 		}
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public ExposureDetectionSummary(int daysSinceLastExposure, ulong matchedKeyCount, byte maximumRiskScore, TimeSpan[] attenuationDurations, int summationRiskScore)
+			: this(daysSinceLastExposure, matchedKeyCount, (int)maximumRiskScore, attenuationDurations, summationRiskScore)
+		{
+		}
+
+		public ExposureDetectionSummary(int daysSinceLastExposure, ulong matchedKeyCount, int highestRiskScore)
+			: this(daysSinceLastExposure, matchedKeyCount, highestRiskScore, null, 0)
+		{
+		}
+
+		public ExposureDetectionSummary(int daysSinceLastExposure, ulong matchedKeyCount, int highestRiskScore, TimeSpan[] attenuationDurations, int summationRiskScore)
 		{
 			DaysSinceLastExposure = daysSinceLastExposure;
 			MatchedKeyCount = matchedKeyCount;
-			MaximumRiskScore = maximumRiskScore;
+			HighestRiskScore = highestRiskScore;
 			AttenuationDurations = attenuationDurations;
 			SummationRiskScore = summationRiskScore;
 		}
@@ -50,7 +63,11 @@ namespace Xamarin.ExposureNotifications
 
 		public ulong MatchedKeyCount { get; }
 
-		public byte MaximumRiskScore { get; }
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Use HighestRiskScore instead.")]
+		public byte MaximumRiskScore => (byte)HighestRiskScore;
+
+		public int HighestRiskScore { get; }
 
 		public TimeSpan[] AttenuationDurations { get; }
 

--- a/Xamarin.ExposureNotification/ExposureNotification.android.cs
+++ b/Xamarin.ExposureNotification/ExposureNotification.android.cs
@@ -206,7 +206,7 @@ namespace Xamarin.ExposureNotifications
 			return new ExposureDetectionSummary(
 				summary.DaysSinceLastExposure,
 				(ulong)summary.MatchedKeyCount,
-				(byte)summary.MaximumRiskScore,
+				summary.MaximumRiskScore,
 				summary.GetAttenuationDurationsInMinutes()
 					.Select(a => TimeSpan.FromMinutes(a)).ToArray(),
 				summary.SummationRiskScore);

--- a/Xamarin.ExposureNotification/ExposureNotification.ios.cs
+++ b/Xamarin.ExposureNotification/ExposureNotification.ios.cs
@@ -229,10 +229,23 @@ namespace Xamarin.ExposureNotifications
 					sumRisk = sron.Int32Value;
 			}
 
+			var maxRisk = 0;
+			dictKey = new NSString("maximumRiskScoreFullRange");
+			if (detectionSummary.Metadata.ContainsKey(dictKey))
+			{
+				var sro = detectionSummary.Metadata.ObjectForKey(dictKey);
+				if (sro is NSNumber sron)
+					maxRisk = sron.Int32Value;
+			}
+            else
+            {
+                maxRisk = detectionSummary.MaximumRiskScore;
+            }
+
 			var summary = new ExposureDetectionSummary(
 				(int)detectionSummary.DaysSinceLastExposure,
 				detectionSummary.MatchedKeyCount,
-				detectionSummary.MaximumRiskScore,
+				maxRisk,
 				attDurTs.ToArray(),
 				sumRisk);
 

--- a/Xamarin.ExposureNotification/ExposureNotification.ios.cs
+++ b/Xamarin.ExposureNotification/ExposureNotification.ios.cs
@@ -237,10 +237,10 @@ namespace Xamarin.ExposureNotifications
 				if (sro is NSNumber sron)
 					maxRisk = sron.Int32Value;
 			}
-            else
-            {
-                maxRisk = detectionSummary.MaximumRiskScore;
-            }
+			else
+			{
+				maxRisk = detectionSummary.MaximumRiskScore;
+			}
 
 			var summary = new ExposureDetectionSummary(
 				(int)detectionSummary.DaysSinceLastExposure,


### PR DESCRIPTION
* The highest risk score of all exposure incidents, it will be a value 0-4096.

`MaximumRiskScore` never existed! 😉 Long live `HighestRiskScore`! #NoBreakingChanges 

Fixes #73 